### PR TITLE
Add consumer base class

### DIFF
--- a/src/YiiAMQP/AbstractConsumer.php
+++ b/src/YiiAMQP/AbstractConsumer.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace YiiAMQP;
+
+/**
+ * Class Consumer
+ *
+ * @author Charles Pick <charles@codemix.com>
+ * @package YiiAMQP
+ */
+abstract class AbstractConsumer extends \CComponent
+{
+    /**
+     * Consumes a message
+     *
+     * @param \PhpAmqpLib\Message\AMQPMessage $message the message to consume
+     *
+     * @return bool true if the message could be consumed
+     */
+    public function consume($message)
+    {
+        $channel = $message->delivery_info['channel']; /* @var \PhpAmqpLib\Channel\AMQPChannel $channel */
+        $tag = $message->delivery_info['delivery_tag'];
+        $decoded = $this->decode($message);
+        if ($decoded === false || !$this->predicate($decoded)) {
+            $channel->basic_nack($tag);
+            return false;
+        }
+        else {
+            $channel->basic_ack($tag);
+            $this->process($decoded);
+            return true;
+        }
+    }
+
+    /**
+     * Determines whether or not the consumer can consume the given message.
+     *
+     * @param array $message the decoded message
+     *
+     * @return bool true if the message is accepted
+     */
+    abstract public function predicate($message);
+
+    /**
+     * Processes a message
+     * @param array $message the decoded message to process
+     */
+    abstract public function process($message);
+
+    /**
+     * Decodes a message
+     *
+     * @param \PhpAmqpLib\Message\AMQPMessage $message the message to decode
+     *
+     * @return bool|array the decoded message, or false if the message content type
+     * is unsupported or the message is malformed.
+     */
+    public function decode($message)
+    {
+        $contentType = $message->get('content_type');
+        if (!stristr($contentType, 'json'))
+            return false;
+        $decoded = json_decode($message->body, true);
+        return $decoded === null ? false : $decoded;
+    }
+}

--- a/src/YiiAMQP/Queue.php
+++ b/src/YiiAMQP/Queue.php
@@ -158,7 +158,7 @@ class Queue extends \CComponent
     /**
      * Registers a callback that can consume messages on the queue.
      *
-     * @param callable $callback the callback to invoke when messages are received
+     * @param AbstractConsumer|callable $callback the consumer or callback to invoke when messages are received
      * @param string $tag Specifies the identifier for the consumer. The consumer tag is
      * local to a channel, so two clients can use the same consumer tags.
      * If this field is empty the server will generate a unique tag.
@@ -171,7 +171,9 @@ class Queue extends \CComponent
      */
     public function consume($callback, $tag = '', $excludeLocal = false, $noAck = false, $isExclusive = true, $noWait = false)
     {
-        if (!is_callable($callback))
+        if ($callback instanceof AbstractConsumer)
+            $callback = array($callback, 'consume');
+        elseif (!is_callable($callback))
             throw new \InvalidArgumentException('First argument to '.__METHOD__.' must be callable!');
         $this->init();
         $this->getClient()->getChannel()->basic_consume(


### PR DESCRIPTION
Adds a base class for message consumers. Child classes implement the `predicate()` and `process()` methods.
